### PR TITLE
Add Action Manager UI

### DIFF
--- a/Rondo-iOS.xcodeproj/project.pbxproj
+++ b/Rondo-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,12 @@
 		6A3752702514E49200BE87D3 /* AdsAskToAskMessageTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A37526F2514E49200BE87D3 /* AdsAskToAskMessageTemplate.swift */; };
 		6A406C45252785340062E76D /* LPAdsTrackingActionTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A406C44252785340062E76D /* LPAdsTrackingActionTemplate.m */; };
 		6A4A39EF2539DF4D00BD8C9A /* AdsTrackingActionTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4A39EE2539DF4D00BD8C9A /* AdsTrackingActionTemplate.swift */; };
+		6A7B2EC32886EDEA00F73EC7 /* MessagesViewController+IAM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2EC22886EDEA00F73EC7 /* MessagesViewController+IAM.swift */; };
+		6A7B2EC52886EE4300F73EC7 /* MessagesViewController+Push.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2EC42886EE4300F73EC7 /* MessagesViewController+Push.swift */; };
+		6A7B2EC72886EEB700F73EC7 /* MessagesViewController+ActionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2EC62886EEB700F73EC7 /* MessagesViewController+ActionManager.swift */; };
+		6A7B2EC92886EF3400F73EC7 /* ActionManagerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2EC82886EF3400F73EC7 /* ActionManagerModel.swift */; };
+		6A7B2ECB2886F50B00F73EC7 /* TextAreaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2ECA2886F50B00F73EC7 /* TextAreaController.swift */; };
+		6A7B2ECD28872A5F00F73EC7 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B2ECC28872A5F00F73EC7 /* Util.swift */; };
 		6A9197D6250A553700B13E05 /* LPAdsAskToAskMessageTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A9197D4250A553700B13E05 /* LPAdsAskToAskMessageTemplate.m */; };
 		8C0B0D93D1B61FAC21A6FC4C /* Pods_Rondo_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DDAFBDF6F1A75C834118A65 /* Pods_Rondo_iOS.framework */; };
 		A82BBF5F24783AB300B99FA0 /* LeanplumEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82BBF5E24783AB300B99FA0 /* LeanplumEnv.swift */; };
@@ -117,6 +123,12 @@
 		6A406C43252785340062E76D /* LPAdsTrackingActionTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPAdsTrackingActionTemplate.h; sourceTree = "<group>"; };
 		6A406C44252785340062E76D /* LPAdsTrackingActionTemplate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LPAdsTrackingActionTemplate.m; sourceTree = "<group>"; };
 		6A4A39EE2539DF4D00BD8C9A /* AdsTrackingActionTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsTrackingActionTemplate.swift; sourceTree = "<group>"; };
+		6A7B2EC22886EDEA00F73EC7 /* MessagesViewController+IAM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+IAM.swift"; sourceTree = "<group>"; };
+		6A7B2EC42886EE4300F73EC7 /* MessagesViewController+Push.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+Push.swift"; sourceTree = "<group>"; };
+		6A7B2EC62886EEB700F73EC7 /* MessagesViewController+ActionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagesViewController+ActionManager.swift"; sourceTree = "<group>"; };
+		6A7B2EC82886EF3400F73EC7 /* ActionManagerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionManagerModel.swift; sourceTree = "<group>"; };
+		6A7B2ECA2886F50B00F73EC7 /* TextAreaController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAreaController.swift; sourceTree = "<group>"; };
+		6A7B2ECC28872A5F00F73EC7 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		6A9197D4250A553700B13E05 /* LPAdsAskToAskMessageTemplate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPAdsAskToAskMessageTemplate.m; sourceTree = "<group>"; };
 		6A9197D5250A553700B13E05 /* LPAdsAskToAskMessageTemplate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LPAdsAskToAskMessageTemplate.h; sourceTree = "<group>"; };
 		871B813E40B9D5721DE92AC4 /* Pods-Rondo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rondo.release.xcconfig"; path = "Target Support Files/Pods-Rondo/Pods-Rondo.release.xcconfig"; sourceTree = "<group>"; };
@@ -213,6 +225,7 @@
 				074C65E723A3C80F00EC586B /* Data */,
 				0739F94324806C4D00B12A6E /* ObjectiveC */,
 				074C65E123A39E4C00EC586B /* Resources */,
+				6A7B2ECC28872A5F00F73EC7 /* Util.swift */,
 			);
 			path = Rondo;
 			sourceTree = "<group>";
@@ -231,6 +244,7 @@
 				074C65E423A3C71500EC586B /* Home */,
 				074C65D223A399D200EC586B /* Main.storyboard */,
 				074C65E223A39EE000EC586B /* TabViewController.swift */,
+				6A7B2ECA2886F50B00F73EC7 /* TextAreaController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -307,6 +321,10 @@
 			isa = PBXGroup;
 			children = (
 				075A175C2422DB20007C6B72 /* MessagesViewController.swift */,
+				6A7B2EC22886EDEA00F73EC7 /* MessagesViewController+IAM.swift */,
+				6A7B2EC42886EE4300F73EC7 /* MessagesViewController+Push.swift */,
+				6A7B2EC62886EEB700F73EC7 /* MessagesViewController+ActionManager.swift */,
+				6A7B2EC82886EF3400F73EC7 /* ActionManagerModel.swift */,
 			);
 			path = Messages;
 			sourceTree = "<group>";
@@ -550,6 +568,7 @@
 				C9E3A1A6278D7BBB00DFAA58 /* Log.swift in Sources */,
 				6A33382E2542C187005F6097 /* AdsTrackingManager.swift in Sources */,
 				6A3752702514E49200BE87D3 /* AdsAskToAskMessageTemplate.swift in Sources */,
+				6A7B2EC52886EE4300F73EC7 /* MessagesViewController+Push.swift in Sources */,
 				6A406C45252785340062E76D /* LPAdsTrackingActionTemplate.m in Sources */,
 				07869B70243CBA4F005E7E94 /* AddAppViewController.swift in Sources */,
 				075A175D2422DB20007C6B72 /* MessagesViewController.swift in Sources */,
@@ -557,6 +576,8 @@
 				074C65E323A39EE000EC586B /* TabViewController.swift in Sources */,
 				078D587F243CDACB00D088BD /* ScannerViewController.swift in Sources */,
 				07869B72243CBB83005E7E94 /* AppsViewController.swift in Sources */,
+				6A7B2EC72886EEB700F73EC7 /* MessagesViewController+ActionManager.swift in Sources */,
+				6A7B2EC32886EDEA00F73EC7 /* MessagesViewController+IAM.swift in Sources */,
 				075A17512422C9EE007C6B72 /* MessageTableViewCell.swift in Sources */,
 				A8B533E424AC192F009F53F3 /* AddEnvironmentViewController.swift in Sources */,
 				075A174C2422AF99007C6B72 /* InboxViewController.swift in Sources */,
@@ -565,6 +586,7 @@
 				074C65CD23A399D200EC586B /* AppDelegate.swift in Sources */,
 				0739F94724806C6D00B12A6E /* LPExceptionCatcher.m in Sources */,
 				6A9197D6250A553700B13E05 /* LPAdsAskToAskMessageTemplate.m in Sources */,
+				6A7B2ECB2886F50B00F73EC7 /* TextAreaController.swift in Sources */,
 				6A3338332542C4AC005F6097 /* LPAdsTrackingManager.m in Sources */,
 				075A17602422E777007C6B72 /* KeyValueTableViewCell.swift in Sources */,
 				078D5881243CEC8000D088BD /* UserDefaultExtension.swift in Sources */,
@@ -572,6 +594,8 @@
 				0739F942248066DC00B12A6E /* EnvironmentsViewController.swift in Sources */,
 				074C65CF23A399D200EC586B /* SceneDelegate.swift in Sources */,
 				6A4A39EF2539DF4D00BD8C9A /* AdsTrackingActionTemplate.swift in Sources */,
+				6A7B2EC92886EF3400F73EC7 /* ActionManagerModel.swift in Sources */,
+				6A7B2ECD28872A5F00F73EC7 /* Util.swift in Sources */,
 				A82BBF5F24783AB300B99FA0 /* LeanplumEnv.swift in Sources */,
 				074C65E923A3C82A00EC586B /* LeanplumApp.swift in Sources */,
 			);

--- a/Rondo/UI/Debug/DebugViewController.swift
+++ b/Rondo/UI/Debug/DebugViewController.swift
@@ -49,7 +49,7 @@ class DebugViewController: FormViewController {
             $0.cellStyle = .value1
             $0.title = "Vars"
             $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
-                let ctrl = AreaController()
+                let ctrl = TextAreaController()
                 ctrl.title = "Vars JSON"
                 ctrl.message = LPJSON.string(fromJSON: VarCache.shared().diffs())
                 return ctrl
@@ -60,7 +60,7 @@ class DebugViewController: FormViewController {
             $0.cellStyle = .value1
             $0.title = "Secured Vars"
             $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
-                let ctrl = AreaController()
+                let ctrl = TextAreaController()
                 ctrl.title = "Secured Vars JSON"
                 ctrl.message = LPJSON.string(fromJSON: VarCache.shared().securedVars())
                 return ctrl
@@ -71,7 +71,7 @@ class DebugViewController: FormViewController {
             $0.cellStyle = .value1
             $0.title = "Variants"
             $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
-                let ctrl = AreaController()
+                let ctrl = TextAreaController()
                 ctrl.title = "Variants JSON"
                 ctrl.message = "Not supported yet"
 //                let variants = VarCache.shared().variants()
@@ -84,7 +84,7 @@ class DebugViewController: FormViewController {
             $0.cellStyle = .value1
             $0.title = "Regions"
             $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
-                let ctrl = AreaController()
+                let ctrl = TextAreaController()
                 ctrl.title = "Regions JSON"
                 ctrl.message = LPJSON.string(fromJSON: VarCache.shared().regions())
                 return ctrl
@@ -144,7 +144,7 @@ class ActionsController: FormViewController {
                 row.cellStyle = .value1
                 row.value = key as? String
                 row.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
-                    let ctrl = AreaController()
+                    let ctrl = TextAreaController()
                     ctrl.title = row.title
                     ctrl.message = LPJSON.string(fromJSON: ActionManager.shared.messages[row.value!])
                     return ctrl
@@ -155,27 +155,6 @@ class ActionsController: FormViewController {
             }
         }
 
-        form +++ section
-    }
-}
-
-class AreaController: FormViewController {
-    var message: String?
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        build()
-    }
-    
-    func build() {
-        let section = Section(title)
-
-        section <<< TextAreaRow() {
-            $0.value = message
-            $0.textAreaHeight = .dynamic(initialTextViewHeight: 96)
-        }
-        
         form +++ section
     }
 }

--- a/Rondo/UI/Messages/ActionManagerModel.swift
+++ b/Rondo/UI/Messages/ActionManagerModel.swift
@@ -1,0 +1,276 @@
+//
+//  ActionManagerModel.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+import Leanplum
+
+enum MessageDisplay: String, CaseIterable {
+    case show = "Show"
+    case discard = "Discard"
+    case delayIndefinitely = "DelayIndefinitely"
+    case delay = "Delay"
+    
+    func messageDisplayChoice() -> ActionManager.MessageDisplayChoice {
+        switch self {
+        case .show:
+            return .show()
+        case .discard:
+            return.discard()
+        case .delayIndefinitely:
+            return .delayIndefinitely()
+        default:
+            return .show()
+        }
+    }
+}
+
+enum MessagePrioritization: String, CaseIterable {
+    case firstOnly = "First Only"
+    case allReversed = "All Reversed"
+}
+
+struct ActionModel: Encodable {
+    let name: String
+    let messageId: String
+    let parent: String
+    let handler: String
+    let actionName: String?
+    
+    static func description(from context: ActionContext, handler: String?, action: String?) -> String {
+        let model = ActionModel(name: context.name,
+                                messageId: context.messageId,
+                                parent: context.parent?.messageId ?? "",
+                                handler: handler ?? "",
+                                actionName: action ?? "")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try! encoder.encode(model)
+        return String(data: data, encoding: .utf8)!
+    }
+}
+
+class ActionManagerModel {
+    init(trackMessageDisplayed: Bool, trackMessageDismissed: Bool, trackMessageActions: Bool) {
+        // invoke didSet
+        defer {
+            self.trackMessageDisplayed = trackMessageDisplayed
+            self.trackMessageDismissed = trackMessageDismissed
+            self.trackMessageActions = trackMessageActions
+        }
+    }
+    
+    convenience init() {
+        self.init(trackMessageDisplayed: true, trackMessageDismissed: true, trackMessageActions: true)
+    }
+    
+    var eventsLog = [String]()
+    
+    var displayChoice: MessageDisplay? {
+        didSet {
+            if let displayChoice = displayChoice {
+                switch displayChoice {
+                    // .delay with seconds is handled separately
+                case .show, .discard, .delayIndefinitely:
+                    ActionManager.shared.shouldDisplayMessage { _ in
+                        return displayChoice.messageDisplayChoice()
+                    }
+                default:
+                    break
+                }
+            } else {
+                ActionManager.shared.shouldDisplayMessage(nil)
+            }
+        }
+    }
+    
+    var prioritizationChoice: MessagePrioritization? {
+        didSet {
+            if oldValue != prioritizationChoice {
+                prioritizationChoiceChanged(prioritizationChoice)
+            }
+        }
+    }
+    
+    var delaySeconds: Int = -1 {
+        didSet {
+            ActionManager.shared.shouldDisplayMessage { [weak self]_ in
+                return .delay(seconds: self?.delaySeconds ?? 0)
+            }
+        }
+    }
+    
+    var isQueueEnabled = ActionManager.shared.isEnabled {
+        didSet {
+            ActionManager.shared.isEnabled = isQueueEnabled
+        }
+    }
+    
+    var isQueuePaused = ActionManager.shared.isPaused {
+        didSet {
+            ActionManager.shared.isPaused = isQueuePaused
+        }
+    }
+    
+    var dismissOnPushArrival = ActionManager.shared.configuration.dismissOnPushArrival {
+        didSet {
+            if oldValue != dismissOnPushArrival {
+                applyConfiguration()
+            }
+        }
+    }
+    
+    var resumeOnEnterForeground = ActionManager.shared.configuration.resumeOnEnterForeground {
+        didSet {
+            if oldValue != resumeOnEnterForeground {
+                applyConfiguration()
+            }
+        }
+    }
+    
+    var trackMessageDisplayed: Bool? {
+        didSet {
+            if trackMessageDisplayed == true {
+                ActionManager.shared.onMessageDisplayed(onMessageHandler(#function))
+            } else {
+                ActionManager.shared.onMessageDisplayed(nil)
+            }
+        }
+    }
+    
+    var trackMessageDismissed: Bool? {
+        didSet {
+            if trackMessageDismissed == true {
+                ActionManager.shared.onMessageDismissed(onMessageHandler(#function))
+            } else {
+                ActionManager.shared.onMessageDismissed(nil)
+            }
+        }
+    }
+    
+    var trackMessageActions: Bool? {
+        didSet {
+            if trackMessageActions == true {
+                ActionManager.shared.onMessageAction(onMessageActionHandler(#function))
+            } else {
+                ActionManager.shared.onMessageAction(nil)
+            }
+        }
+    }
+    
+    lazy var onMessageHandler: ((String) -> (ActionContext) -> ()) = { handler in
+        { context in
+            self.addAction(context: context, handler: handler)
+        }
+    }
+    
+    lazy var onMessageActionHandler: ((String) -> (String, ActionContext) -> ()) = { handler in
+        { action, context in
+            self.addAction(action: action, context: context, handler: handler)
+        }
+    }
+    
+    lazy var onMessageDismissed: ((ActionContext) -> ()) = { context in
+        self.addAction(context: context, handler: #function)
+    }
+    
+    func applyConfiguration() {
+        ActionManager.shared.configuration = ActionManager.Configuration(dismissOnPushArrival: dismissOnPushArrival,
+                                                                         resumeOnEnterForeground: resumeOnEnterForeground)
+    }
+    
+    func prioritizationChoiceChanged(_ prioritization: MessagePrioritization?) {
+        switch prioritization {
+        case .firstOnly:
+            ActionManager.shared.prioritizeMessages { contexts, trigger in
+                guard let first = contexts.first else {
+                    return []
+                }
+                return [first]
+            }
+        case .allReversed:
+            ActionManager.shared.prioritizeMessages { contexts, trigger in
+                return contexts.reversed()
+            }
+        default:
+            ActionManager.shared.prioritizeMessages(nil)
+            break
+        }
+    }
+    
+    func triggerDelayedMessages() {
+        ActionManager.shared.triggerDelayedMessages()
+    }
+    
+    func addAction(context: ActionContext, handler: String) {
+        addAction(action: nil, context: context, handler: handler)
+    }
+    
+    func addAction(action: String?, context: ActionContext, handler: String) {
+        let desc = ActionModel.description(from: context, handler: handler, action: action)
+        eventsLog.append(desc)
+    }
+    
+    func showEventLogs() -> UIViewController {
+        let ctrl = TextAreaController()
+        ctrl.title = "Action Logs"
+        ctrl.message = eventsLog.joined(separator: ", \n")
+        return ctrl
+    }
+    
+    func resetEventLogs() {
+        eventsLog.removeAll()
+    }
+    
+    func showMessageQueue() -> UIViewController {
+        var log = [String]()
+        for ctx in queueContexts {
+            log.append(ActionModel.description(from: ctx, handler: nil, action: nil))
+        }
+        
+        let ctrl = TextAreaController()
+        ctrl.title = "Queue"
+        ctrl.message = log.joined(separator: ", \n")
+        return ctrl
+    }
+    
+    func showDelayedMessageQueue() -> UIViewController {
+        var log = [String]()
+        for ctx in delayedQueueContexts {
+            log.append(ActionModel.description(from: ctx, handler: nil, action: nil))
+        }
+        
+        let ctrl = TextAreaController()
+        ctrl.title = "Delayed Queue"
+        ctrl.message = log.joined(separator: ", \n")
+        return ctrl
+    }
+    
+    var queueContexts: [ActionContext] {
+        getActionManagerQueueContexts("queue")
+    }
+    
+    var delayedQueueContexts: [ActionContext] {
+        getActionManagerQueueContexts("delayedQueue")
+    }
+
+    /// Accessing the ActionManager Queues which are private lazy properties of private type Queue
+    /// The Queue holds a private array of the private type Action
+    /// The Action holds a context
+    func getActionManagerQueueContexts(_ queueName: String) -> [ActionContext] {
+        let queue = Util.getPrivateValue(subject: ActionManager.shared, label: queueName, true, true)
+        
+        if let queue = queue {
+            if let arr = Util.getPrivateValue(subject: queue, label: "queue") as? [Any] {
+                return arr.map { action in
+                    return Util.getPrivateValue(subject: action, label: "context") as? ActionContext
+                }.compactMap { $0 }
+            }
+        }
+        return []
+    }
+}

--- a/Rondo/UI/Messages/MessagesViewController+ActionManager.swift
+++ b/Rondo/UI/Messages/MessagesViewController+ActionManager.swift
@@ -1,0 +1,166 @@
+//
+//  MessagesViewController+ActionManager.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+import Eureka
+
+extension MessagesViewController {
+    func buildActionManager() {
+        form.removeAll()
+        
+        buildQueueOptions()
+        buildMessageDisplayHandlers()
+        buildOnMessage()
+    }
+    
+    func buildQueueOptions() {
+        let section = Section("Action Manager Configuration")
+        
+        section <<< SwitchRow {
+            $0.title = "Pause Queue"
+            $0.value = self.model.isQueuePaused
+        }.onChange({ row in
+            self.model.isQueuePaused = row.value!
+        })
+        section <<< SwitchRow {
+            $0.title = "Disable Queue"
+            $0.value = !self.model.isQueueEnabled
+        }.onChange({ row in
+            self.model.isQueueEnabled = !row.value!
+        })
+        section <<< SwitchRow {
+            $0.title = "Dismiss on Push Opened"
+            $0.value = self.model.dismissOnPushArrival
+        }.onChange({ row in
+            self.model.dismissOnPushArrival = row.value!
+        })
+        section <<< SwitchRow {
+            $0.title = "Resume on App Foreground"
+            $0.value = self.model.resumeOnEnterForeground
+        }.onChange({ row in
+            self.model.resumeOnEnterForeground = row.value!
+        })
+        
+        section <<< ButtonRow {
+            $0.title = "View Queue"
+            $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
+                self.model.showMessageQueue()
+            }), onDismiss: nil)
+        }
+        
+        form +++ section
+    }
+    
+    func buildMessageDisplayHandlers() {
+        let section = SelectableSection<ListCheckRow<MessageDisplay>>("Should Display Message",
+                                                                      selectionType: .singleSelection(enableDeselection: true))
+        
+        let options = MessageDisplay.allCases
+        for option in options {
+            section <<< ListCheckRow<MessageDisplay>(option.rawValue){ listRow in
+                listRow.title = option.rawValue
+                listRow.tag = option.rawValue
+                listRow.selectableValue = option
+                listRow.value = nil
+            }
+        }
+        
+        form +++ section
+        
+        let defaultDelay = 5
+        let delaySection = Section() {
+            $0.hidden = Condition.function([MessageDisplay.delay.rawValue], { form in
+                let row = form.rowBy(tag: MessageDisplay.delay.rawValue) as? ListCheckRow<MessageDisplay>
+                if row?.value != nil {
+                    return false
+                }
+                return true
+            })
+        }
+        <<< IntRow(){
+            $0.title = "Delay Seconds"
+            $0.tag = "delaySeconds"
+            $0.value = defaultDelay
+        }
+        <<< ButtonRow(){
+            $0.title = "Set"
+        }.onCellSelection({ [weak self] cell, row in
+            let secondsRow = self?.form.rowBy(tag: "delaySeconds") as? IntRow
+            self?.model.delaySeconds = secondsRow?.value ?? defaultDelay
+        })
+        
+        form +++ delaySection
+        
+        form +++ Section()
+        <<< ButtonRow {
+            $0.title = "View Delayed Queue"
+            $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
+                self.model.showDelayedMessageQueue()
+            }), onDismiss: nil)
+        }
+        <<< ButtonRow(){
+            $0.title = "Trigger Delayed Messages"
+        }.onCellSelection({ [weak self] cell, row in
+            self?.model.triggerDelayedMessages()
+        })
+        
+        let prioritySection = SelectableSection<ListCheckRow<MessagePrioritization>>("Prioritize Messages",
+                                                                                     selectionType: .singleSelection(enableDeselection: true))
+        
+        let prioritizeOptions = MessagePrioritization.allCases
+        for option in prioritizeOptions {
+            prioritySection <<< ListCheckRow<MessagePrioritization>(){ listRow in
+                listRow.title = option.rawValue
+                listRow.selectableValue = option
+                listRow.value = nil
+            }
+        }
+        
+        form +++ prioritySection
+    }
+    
+    func buildOnMessage() {
+        let section = Section("On Message Handlers")
+        
+        section <<< SwitchRow {
+            $0.title = "onMessageDisplayed"
+            $0.value = self.model.trackMessageDisplayed
+            $0.onChange { row in
+                self.model.trackMessageDisplayed = row.value
+            }
+        }
+        section <<< SwitchRow {
+            $0.title = "onMessageDismissed"
+            $0.value = self.model.trackMessageDismissed
+            $0.onChange { row in
+                self.model.trackMessageDismissed = row.value
+            }
+        }
+        section <<< SwitchRow {
+            $0.title = "onMessageAction"
+            $0.value = self.model.trackMessageActions
+            $0.onChange { row in
+                self.model.trackMessageActions = row.value
+            }
+        }
+        
+        section <<< ButtonRow {
+            $0.title = "View Event Logs"
+            $0.presentationMode = .show(controllerProvider: .callback(builder: { () -> UIViewController in
+                self.model.showEventLogs()
+            }), onDismiss: nil)
+        }
+        section <<< ButtonRow {
+            $0.title = "Delete Event Logs"
+        }.onCellSelection({ cell, row in
+            self.model.resetEventLogs()
+        })
+        
+        form +++ section
+    }
+}

--- a/Rondo/UI/Messages/MessagesViewController+IAM.swift
+++ b/Rondo/UI/Messages/MessagesViewController+IAM.swift
@@ -1,0 +1,92 @@
+//
+//  MessagesViewController+IAM.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+import Eureka
+
+extension MessagesViewController {
+    func buildIAM() {
+        form.removeAll()
+        buildTemplateMessages()
+        buildActions()
+        buildRichMessages()
+    }
+    
+    func buildTemplateMessages() {
+        let section = Section("In-App Messages")
+        
+        section <<< LabelRow {
+            $0.title = "Alert"
+            $0.tag = "alert"
+        }
+        section <<< LabelRow {
+            $0.title = "Center Popup"
+            $0.tag = "centerPopup"
+        }
+        section <<< LabelRow {
+            $0.title = "Confirm"
+            $0.tag = "confirm"
+        }
+        section <<< LabelRow {
+            $0.title = "Interstitial"
+            $0.tag = "interstitial"
+        }
+        section <<< LabelRow {
+            $0.title = "Web Interstitial"
+            $0.tag = "webInterstitial"
+        }
+        section <<< LabelRow {
+            $0.title = "Ads Pre-Permission"
+            $0.tag = "adsAskToAsk"
+        }
+        
+        form +++ section
+    }
+    
+    func buildActions() {
+        let section = Section("Actions")
+        
+        section <<< LabelRow {
+            $0.title = "Open URL"
+            $0.tag = "openURL"
+        }
+        section <<< LabelRow {
+            $0.title = "Request App Rating"
+            $0.tag = "appRating"
+        }
+        section <<< LabelRow {
+            $0.title = "Register for Push"
+            $0.tag = "registerPush"
+        }
+        section <<< LabelRow {
+            $0.title = "Register for Ads Tracking"
+            $0.tag = "registerAdsTracking"
+        }
+        
+        form +++ section
+    }
+    
+    func buildRichMessages() {
+        let section = Section("Rich In-App Messaging")
+        
+        section <<< LabelRow {
+            $0.title = "Banner"
+            $0.tag = "banner"
+        }
+        section <<< LabelRow {
+            $0.title = "Rich Interstitial"
+            $0.tag = "richInterstitial"
+        }
+        section <<< LabelRow {
+            $0.title = "Star Rating"
+            $0.tag = "starRating"
+        }
+        
+        form +++ section
+    }
+}

--- a/Rondo/UI/Messages/MessagesViewController+Push.swift
+++ b/Rondo/UI/Messages/MessagesViewController+Push.swift
@@ -1,0 +1,90 @@
+//
+//  MessagesViewController+Push.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+import Eureka
+
+extension MessagesViewController {
+    func buildPush() {
+        form.removeAll()
+        
+        buildPushPermissions()
+        buildPushTriggers()
+    }
+    
+    func buildPushPermissions() {
+        let section = Section("Push Permissions")
+        
+        section <<< LabelRow {
+            $0.title = "Push Permissions Through Leanplum"
+            $0.tag = "registerPush"
+        }
+        
+        section <<< LabelRow {
+            $0.title = "System Push Permission"
+            $0.tag = "systemPush"
+        }
+        
+        form +++ section
+    }
+    
+    func buildPushTriggers() {
+        let section = Section("Push Notifications")
+        
+        section <<< LabelRow {
+            $0.title = "Push with Emoji"
+            $0.tag = "pushRender"
+        }
+        section <<< LabelRow {
+            $0.title = "Push with Image"
+            $0.tag = "pushImage"
+        }
+        section <<< LabelRow {
+            $0.title = "Push with New IAM"
+            $0.tag = "pushAction"
+        }
+        section <<< LabelRow {
+            $0.title = "Push with Existing IAM"
+            $0.tag = "pushExistingAction"
+        }
+        section <<< LabelRow {
+            $0.title = "Push with Open URL"
+            $0.tag = "pushURL"
+        }
+        section <<< LabelRow {
+            $0.title = "Push with Text Formatting"
+            $0.tag = "pushOptions"
+        }
+        section <<< LabelRow {
+            $0.title = "Local Push"
+            $0.tag = "pushLocal"
+        }
+        section <<< LabelRow {
+            $0.title = "Local Push with Cancel"
+            $0.tag = "pushLocalCancel"
+        }
+        section <<< LabelRow {
+            $0.title = "Cancel Local Push with Cancel"
+            $0.tag = "Cancel"
+        }
+        section <<< LabelRow {
+            $0.title = "Muted Push"
+            $0.tag = "pushMuted"
+        }
+        section <<< LabelRow {
+            $0.title = "Local Push with Same Priority"
+            $0.tag = "pushLocalSamePriorityTime"
+        }
+        section <<< LabelRow {
+            $0.title = "Local Push with Same Priority Different Time"
+            $0.tag = "pushLocalSamePriorityDifferentTime"
+        }
+        
+        form +++ section
+    }
+}

--- a/Rondo/UI/Messages/MessagesViewController.swift
+++ b/Rondo/UI/Messages/MessagesViewController.swift
@@ -11,7 +11,23 @@ import Eureka
 import Leanplum
 
 class MessagesViewController: FormViewController {
-    private let segmentedControl = UISegmentedControl(items: ["IAM", "Push"])
+    enum MessageSegments: String, CaseIterable, CustomStringConvertible {
+        case iam = "IAM"
+        case push = "Push"
+        case actionManager = "Action Manager"
+        
+        var description: String {
+            return rawValue
+        }
+        
+        static var items: [String] {
+            return MessageSegments.allCases.map({$0.rawValue})
+        }
+    }
+    
+    private let segmentedControl = UISegmentedControl(items: MessageSegments.items)
+
+    let model = ActionManagerModel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,6 +48,31 @@ class MessagesViewController: FormViewController {
         buildIAM()
     }
     
+    func addSegmentedControl() {
+        segmentedControl.addTarget(self, action: #selector(MessagesViewController.didChangeSegment), for: .valueChanged)
+        segmentedControl.selectedSegmentIndex = 0;
+        segmentedControl.sizeToFit()
+        
+        navigationItem.titleView = segmentedControl
+    }
+    
+    @objc func didChangeSegment() {
+        title = segmentedControl.titleForSegment(at: segmentedControl.selectedSegmentIndex)
+
+        guard let title = title, let segment = MessageSegments(rawValue: title) else {
+            return
+        }
+        
+        switch segment {
+        case .iam:
+            buildIAM()
+        case .push:
+            buildPush()
+        case .actionManager:
+            buildActionManager()
+        }
+    }
+    
     func requestSystemPushPermission() {
         let center = UNUserNotificationCenter.current()
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
@@ -48,180 +89,5 @@ class MessagesViewController: FormViewController {
                 }
             }
         }
-    }
-    
-    func addSegmentedControl() {
-        segmentedControl.addTarget(self, action: #selector(MessagesViewController.didChangeSegment), for: .valueChanged)
-        segmentedControl.selectedSegmentIndex = 0;
-        segmentedControl.sizeToFit()
-        
-        navigationItem.titleView = segmentedControl
-    }
-    
-    @objc func didChangeSegment() {
-        title = segmentedControl.titleForSegment(at: segmentedControl.selectedSegmentIndex)
-        if segmentedControl.selectedSegmentIndex == 0 {
-            buildIAM()
-        } else {
-            buildPush()
-        }
-    }
-    
-    func buildIAM() {
-        form.removeAll()
-        buildTemplateMessages()
-        buildActions()
-        buildRichMessages()
-    }
-    
-    func buildPush() {
-        form.removeAll()
-        
-        buildPushPermissions()
-        buildPushTriggers()
-    }
-    
-    func buildPushPermissions() {
-        let section = Section("Push Permissions")
-        
-        section <<< LabelRow {
-            $0.title = "Push Permissions Through Leanplum"
-            $0.tag = "registerPush"
-        }
-        
-        section <<< LabelRow {
-            $0.title = "System Push Permission"
-            $0.tag = "systemPush"
-        }
-        
-        form +++ section
-    }
-    
-    func buildPushTriggers() {
-        let section = Section("Push Notifications")
-        
-        section <<< LabelRow {
-            $0.title = "Push with Emoji"
-            $0.tag = "pushRender"
-        }
-        section <<< LabelRow {
-            $0.title = "Push with Image"
-            $0.tag = "pushImage"
-        }
-        section <<< LabelRow {
-            $0.title = "Push with New IAM"
-            $0.tag = "pushAction"
-        }
-        section <<< LabelRow {
-            $0.title = "Push with Existing IAM"
-            $0.tag = "pushExistingAction"
-        }
-        section <<< LabelRow {
-            $0.title = "Push with Open URL"
-            $0.tag = "pushURL"
-        }
-        section <<< LabelRow {
-            $0.title = "Push with Text Formatting"
-            $0.tag = "pushOptions"
-        }
-        section <<< LabelRow {
-            $0.title = "Local Push"
-            $0.tag = "pushLocal"
-        }
-        section <<< LabelRow {
-            $0.title = "Local Push with Cancel"
-            $0.tag = "pushLocalCancel"
-        }
-        section <<< LabelRow {
-            $0.title = "Cancel Local Push with Cancel"
-            $0.tag = "Cancel"
-        }
-        section <<< LabelRow {
-            $0.title = "Muted Push"
-            $0.tag = "pushMuted"
-        }
-        section <<< LabelRow {
-            $0.title = "Local Push with Same Priority"
-            $0.tag = "pushLocalSamePriorityTime"
-        }
-        section <<< LabelRow {
-            $0.title = "Local Push with Same Priority Different Time"
-            $0.tag = "pushLocalSamePriorityDifferentTime"
-        }
-        
-        form +++ section
-    }
-    
-    func buildTemplateMessages() {
-        let section = Section("In-App Messages")
-        
-        section <<< LabelRow {
-            $0.title = "Alert"
-            $0.tag = "alert"
-        }
-        section <<< LabelRow {
-            $0.title = "Center Popup"
-            $0.tag = "centerPopup"
-        }
-        section <<< LabelRow {
-            $0.title = "Confirm"
-            $0.tag = "confirm"
-        }
-        section <<< LabelRow {
-            $0.title = "Interstitial"
-            $0.tag = "interstitial"
-        }
-        section <<< LabelRow {
-            $0.title = "Web Interstitial"
-            $0.tag = "webInterstitial"
-        }
-        section <<< LabelRow {
-            $0.title = "Ads Pre-Permission"
-            $0.tag = "adsAskToAsk"
-        }
-        
-        form +++ section
-    }
-    
-    func buildActions() {
-        let section = Section("Actions")
-        
-        section <<< LabelRow {
-            $0.title = "Open URL"
-            $0.tag = "openURL"
-        }
-        section <<< LabelRow {
-            $0.title = "Request App Rating"
-            $0.tag = "appRating"
-        }
-        section <<< LabelRow {
-            $0.title = "Register for Push"
-            $0.tag = "registerPush"
-        }
-        section <<< LabelRow {
-            $0.title = "Register for Ads Tracking"
-            $0.tag = "registerAdsTracking"
-        }
-        
-        form +++ section
-    }
-    
-    func buildRichMessages() {
-        let section = Section("Rich In-App Messaging")
-        
-        section <<< LabelRow {
-            $0.title = "Banner"
-            $0.tag = "banner"
-        }
-        section <<< LabelRow {
-            $0.title = "Rich Interstitial"
-            $0.tag = "richInterstitial"
-        }
-        section <<< LabelRow {
-            $0.title = "Star Rating"
-            $0.tag = "starRating"
-        }
-        
-        form +++ section
     }
 }

--- a/Rondo/UI/TextAreaController.swift
+++ b/Rondo/UI/TextAreaController.swift
@@ -1,0 +1,31 @@
+//
+//  TextAreaController.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+import Eureka
+
+class TextAreaController: FormViewController {
+    var message: String?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        build()
+    }
+    
+    func build() {
+        let section = Section(title)
+
+        section <<< TextAreaRow() {
+            $0.value = message
+            $0.textAreaHeight = .dynamic(initialTextViewHeight: 96)
+        }
+        
+        form +++ section
+    }
+}

--- a/Rondo/Util.swift
+++ b/Rondo/Util.swift
@@ -1,0 +1,26 @@
+//
+//  Util.swift
+//  Rondo-iOS
+//
+//  Created by Nikola Zagorchev on 19.07.22.
+//  Copyright © 2022 Leanplum. All rights reserved.
+//
+
+import Foundation
+
+struct Util {
+    static func getPrivateValue(subject: Any, label: String, _ isLazy: Bool = false, _ isOptional: Bool = false) -> Any? {
+        let mirror = Mirror(reflecting: subject)
+        let fullLabel = isLazy ? "$__lazy_storage_$_" + label : label
+        let child = mirror.children.first { (_label: String?, value: Any) in
+            _label == fullLabel
+        }
+        
+        let value = child?.value
+        
+        if isOptional, let value = value {
+            return Mirror(reflecting: value).children.first?.value
+        }
+        return value
+    }
+}


### PR DESCRIPTION
Add UI for using Action Manager IAM handlers and configurations.
Settings are persisted in memory only.

### Configuration
- Pause Queue (switch)
- Enable Queue (switch)
- Dismiss on push opened (switch)
- Resume queue on app enters foreground (switch)
- View queue contexts

### Should display message
- Show
- Discard
- Delay
- Delay indefinitely 

If the option is deselected, the handler is removed.
When Delay is used, a separate section opens to specify the delay in seconds. Click the Set button to set it.

After the handler is set to Delay (or Delay indefinitely), set it back to Show if you want to trigger the delayed messages.

### Delayed
- View Delayed messages
- Trigger delayed messages

### Prioritize messages
- First only
- All reversed

If no option is selected or a selected option is deselected - the handler is removed, returning to default behavior.

### On Message handlers
Adds logs for each action which can be seen from the button, or reset.

### Logs
All logs are shown in JSON format, pretty printed. Example:
```json
{
  "actionName" : "Dismiss action",
  "handler" : "trackMessageActions",
  "messageId" : "5458818674327552",
  "name" : "Dismiss action",
  "parent" : "5458818674327552"
}
```
